### PR TITLE
Add team annotations rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,14 @@ var _stringLiteralBlacklist = require('./string-literal-blacklist');
 
 var _stringLiteralBlacklist2 = _interopRequireDefault(_stringLiteralBlacklist);
 
+var _teamAnnotations = require('./team-annotations');
+
+var _teamAnnotations2 = _interopRequireDefault(_teamAnnotations);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var rules = exports.rules = {
   'global-payroll-properties': _globalPayrollProperties2.default,
-  'string-literal-blacklist': _stringLiteralBlacklist2.default
+  'string-literal-blacklist': _stringLiteralBlacklist2.default,
+  'team-annotations': _teamAnnotations2.default
 };

--- a/lib/team-annotations.js
+++ b/lib/team-annotations.js
@@ -1,0 +1,98 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+function teamAnnotations(context) {
+  var _ref = context.options[0] || {},
+      missions = _ref.missions,
+      teams = _ref.teams;
+
+  var sourceCode = context.getSourceCode();
+  var comments = sourceCode.getAllComments();
+
+  var MISSION_REGEX = / @mission ([\w| ]*)/;
+  function getMissionTag() {
+    return comments.find(function (comment) {
+      return comment.loc.start.line === 1 && comment.value.match(MISSION_REGEX);
+    });
+  }
+
+  function isValidMission(missionTag) {
+    return missions.includes(missionTag.value.match(MISSION_REGEX)[1]);
+  }
+
+  var TEAM_REGEX = / @team ([\w| ]*)/;
+  function getTeamTag() {
+    return comments.find(function (comment) {
+      return comment.loc.start.line === 2 && comment.value.match(TEAM_REGEX);
+    });
+  }
+
+  function isValidTeam(teamTag) {
+    return teams.includes(teamTag.value.match(TEAM_REGEX)[1]);
+  }
+
+  return {
+    Program: function Program() {
+      var missionTag = getMissionTag();
+      if (!missionTag) {
+        var report = {
+          node: { loc: { start: { line: 1, column: 0 } } },
+          message: 'A mission annotation is required at the top of the file (i.e. `# @mission Owning Mission`).'
+        };
+        context.report(report);
+      } else {
+        var isValid = isValidMission(missionTag);
+        if (!isValid) {
+          var _report = {
+            node: missionTag,
+            message: 'The mission annotation must be a valid mission.'
+          };
+          context.report(_report);
+        }
+      }
+
+      var teamTag = getTeamTag();
+      if (!teamTag) {
+        var _report2 = {
+          node: { loc: { start: { line: 2, column: 0 } } },
+          message: 'A team annotation is required at the second line of the file (i.e. `# @team Owning Team`).'
+        };
+        context.report(_report2);
+      } else {
+        var _isValid = isValidTeam(teamTag);
+        if (!_isValid) {
+          var _report3 = {
+            node: teamTag,
+            message: 'The team annotation must be a valid team.'
+          };
+          context.report(_report3);
+        }
+      }
+
+      return;
+    }
+  };
+}
+
+teamAnnotations.schema = [{
+  'type': 'object',
+  'properties': {
+    'missions': {
+      'type': 'array',
+      'items': {
+        'type': 'string'
+      }
+    },
+    'teams': {
+      'type': 'array',
+      'items': {
+        'type': 'string'
+      }
+    }
+  },
+  'additionalProperties': false
+}];
+
+exports.default = teamAnnotations;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/eslint-plugin-gusto",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Custom Gusto ESLint rules",
   "repository": "Gusto/eslint-plugin-gusto",
   "main": "lib/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import globalPayrollProperties from './global-payroll-properties';
 import stringLiteralBlacklist from './string-literal-blacklist';
+import teamAnnotations from './team-annotations';
 
 export const rules = {
   'global-payroll-properties': globalPayrollProperties,
-  'string-literal-blacklist': stringLiteralBlacklist
+  'string-literal-blacklist': stringLiteralBlacklist,
+  'team-annotations': teamAnnotations
 };

--- a/src/team-annotations.js
+++ b/src/team-annotations.js
@@ -1,0 +1,91 @@
+function teamAnnotations(context) {
+  const { missions, teams } = (context.options[0] || {});
+
+  const sourceCode = context.getSourceCode();
+  const comments = sourceCode.getAllComments();
+
+  const MISSION_REGEX = / @mission ([\w| ]*)/;
+  function getMissionTag() {
+    return comments.find((comment) => {
+      return comment.loc.start.line === 1 && comment.value.match(MISSION_REGEX);
+    });
+  }
+
+  function isValidMission(missionTag) {
+    return missions.includes(missionTag.value.match(MISSION_REGEX)[1]);
+  }
+
+  const TEAM_REGEX = / @team ([\w| ]*)/;
+  function getTeamTag() {
+    return comments.find((comment) => {
+      return comment.loc.start.line === 2 && comment.value.match(TEAM_REGEX);
+    });
+  }
+
+  function isValidTeam(teamTag) {
+    return teams.includes(teamTag.value.match(TEAM_REGEX)[1]);
+  }
+
+  return {
+    Program() {
+      const missionTag = getMissionTag();
+      if (!missionTag) {
+        const report = {
+          node: { loc: { start: { line: 1, column: 0 } }},
+          message: 'A mission annotation is required at the top of the file (i.e. `# @mission Owning Mission`).'
+        };
+        context.report(report);
+      } else {
+        const isValid = isValidMission(missionTag);
+        if (!isValid) {
+          const report = {
+            node: missionTag,
+            message: 'The mission annotation must be a valid mission.'
+          };
+          context.report(report);
+        }
+      }
+
+      const teamTag = getTeamTag();
+      if (!teamTag) {
+        const report = {
+          node: { loc: { start: { line: 2, column: 0 } }},
+          message: 'A team annotation is required at the second line of the file (i.e. `# @team Owning Team`).'
+        };
+        context.report(report);
+      }  else {
+        const isValid = isValidTeam(teamTag);
+        if (!isValid) {
+          const report = {
+            node: teamTag,
+            message: 'The team annotation must be a valid team.'
+          };
+          context.report(report);
+        }
+      }
+
+      return;
+    }
+  };
+}
+
+teamAnnotations.schema = [{
+  'type': 'object',
+  'properties': {
+    'missions': {
+      'type': 'array',
+      'items': {
+        'type': 'string'
+      }
+    },
+    'teams': {
+      'type': 'array',
+      'items': {
+        'type': 'string'
+      }
+    }
+  },
+  'additionalProperties': false
+}];
+
+export default teamAnnotations;

--- a/src/team-annotations.js
+++ b/src/team-annotations.js
@@ -12,7 +12,7 @@ function teamAnnotations(context) {
   }
 
   function isValidMission(missionTag) {
-    return missions.includes(missionTag.value.match(MISSION_REGEX)[1]);
+    return missions.indexOf(missionTag.value.match(MISSION_REGEX)[1]) >= 0;
   }
 
   const TEAM_REGEX = / @team ([\w| ]*)/;
@@ -23,7 +23,7 @@ function teamAnnotations(context) {
   }
 
   function isValidTeam(teamTag) {
-    return teams.includes(teamTag.value.match(TEAM_REGEX)[1]);
+    return teams.indexOf(teamTag.value.match(TEAM_REGEX)[1]) >= 0;
   }
 
   return {

--- a/tests/lib/rules/team-annotations.js
+++ b/tests/lib/rules/team-annotations.js
@@ -1,0 +1,107 @@
+import rule from '../../../src/team-annotations';
+import { RuleTester } from 'eslint';
+
+const options = [
+  {
+    missions: [ 'Mission' ],
+    teams: [ 'Team' ],
+  }
+];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+ruleTester.run('team-annotations', rule, {
+  valid: [
+    {
+      code: [
+        '// @mission Mission',
+        '// @team Team'
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      }
+    },
+  ],
+  invalid: [
+    {
+      code: [
+        '// @mission Mission'
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      },
+      errors: [{ message: "A team annotation is required at the second line of the file (i.e. `# @team Owning Team`)." }]
+    },
+    {
+      code: [
+        '// @mission Fake Mission',
+        '// @team Team'
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      },
+      errors: [{ message: "The mission annotation must be a valid mission." }]
+    },
+    {
+      code: [
+        '',
+        '// @team Team'
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      },
+      errors: [{ message: "A mission annotation is required at the top of the file (i.e. `# @mission Owning Mission`)." }]
+    },
+    {
+      code: [
+        '// @mission Mission',
+        '// @team Fake Team'
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      },
+      errors: [{ message: "The team annotation must be a valid team." }]
+    },
+    {
+      code: [
+        'function print1() { console.log(1); }',
+      ].join("\n"),
+      options,
+      env: {
+        es6: true
+      },
+      ecmaFeatures: {
+        jsx: true
+      },
+      errors: [
+        { message: "A mission annotation is required at the top of the file (i.e. `# @mission Owning Mission`)." },
+        { message: "A team annotation is required at the second line of the file (i.e. `# @team Owning Team`)." }
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
I have some branches that tag the frontend files according to their owners, this will add a linting rule to make sure its available in all files - similar to our rubocop rule.