### PR TITLE
Add linter to warn against using data-testid

### DIFF
--- a/src/no-data-testid.js
+++ b/src/no-data-testid.js
@@ -1,0 +1,11 @@
+function noDataTestId(context){
+  return {
+    "JSXAttribute": function(node) {
+      if(node.name.type === "JSXIdentifier" && node.name.name === 'data-testid') {
+        context.report(node, "Avoid using `data-testid` when possible. Try to test your component as a user would.");
+      }
+    }
+  };
+}
+
+export default noDataTestId;

--- a/tests/lib/rules/no-data-testid.js
+++ b/tests/lib/rules/no-data-testid.js
@@ -1,0 +1,43 @@
+import rule from '../../../src/no-data-testid';
+import { RuleTester } from 'eslint';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    env: {
+      es6: true
+    },
+  },
+});
+
+ruleTester.run('no-data-testid', rule, {
+  valid: [
+    {
+      code: "const test = <div className='test'/>",
+      ecmaFeatures: {
+        jsx: true,
+      },
+      env: {
+        es6: true
+      },
+    }
+  ],
+  invalid: [
+    {
+      code: "const test = <div data-testid='myid'/>",
+      ecmaFeatures: {
+        jsx: true,
+      },
+      env: {
+        es6: true
+      },
+      errors: [
+        {
+          message: "Avoid using `data-testid` when possible. Try to test your component as a user would.",
+        }
+      ],
+    }
+  ],
+});


### PR DESCRIPTION
Co-authored-by: Jesse Zhou <jesse.zhou@gusto.com>