### PR TITLE
[Gusto-Eslint] Add rule to allow ZP to use TS as default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ export const rules = {
   'no-restricted-call-result-use': noRestrictedCallResultUse,
   'string-literal-blacklist': stringLiteralBlacklist,
   'team-annotations': teamAnnotations,
-  'prefer-typescript-over-javascript': preferTypescriptOverJavascript
+  'prefer-typescript-over-javascript': preferTypescriptOverJavascript,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import globalPayrollProperties from './global-payroll-properties';
 import noRestrictedCallResultUse from './no-restricted-call-result-use';
 import stringLiteralBlacklist from './string-literal-blacklist';
 import teamAnnotations from './team-annotations';
+import preferTypescriptOverJavascript from './prefer-typescript-over-javascript';
 
 // eslint-disable-next-line import/prefer-default-export
 export const rules = {
@@ -9,4 +10,5 @@ export const rules = {
   'no-restricted-call-result-use': noRestrictedCallResultUse,
   'string-literal-blacklist': stringLiteralBlacklist,
   'team-annotations': teamAnnotations,
+  'prefer-typescript-over-javascript': preferTypescriptOverJavascript
 };

--- a/src/prefer-typescript-over-javascript.js
+++ b/src/prefer-typescript-over-javascript.js
@@ -1,0 +1,21 @@
+// https://eslint.org/docs/developer-guide/working-with-rules
+
+function preferTypescriptOverJavascript(context) {
+  return {
+    Program(node) {
+      const filename = context.getFilename();
+      if (filename.endsWith('.jsx') || filename.endsWith('.js')) {
+        const [firstChild] = node.body;
+        // It comes back like this
+        // "options":[{"message":"custom message"}]}
+        const { message } = context.options[0];
+        context.report({
+          node: firstChild,
+          message: `JavaScript files are not allowed. Use TypeScript instead. ${message}`,
+        });
+      }
+    },
+  };
+}
+
+export default preferTypescriptOverJavascript;


### PR DESCRIPTION
Instead of using no-restricted-syntax, I decided to make a custom rule so that we could reuse it + not deal with weird conflicts between different levels of eslintrc.js using other forms of no-restricted-syntax. It will be easier to add eslint_todo for this rule explicitly and not have any overlaps / conflicts with other rules.

Example of it working in ZP when hooking it up via `yarn link`

![CleanShot 2021-12-02 at 00 51 00](https://user-images.githubusercontent.com/13022754/144389232-eae11679-424c-4593-8385-f6d8af86507e.png)
