### PR TITLE
add rule to prevent use of dumb quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 npm-debug.log
 /.history
-lib
+/lib
 .DS_Store
 gusto-eslint-plugin-gusto*.tgz
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
 import globalPayrollProperties from './global-payroll-properties';
+import noDumbQuotes from './no-dumb-quotes';
 import noRestrictedCallResultUse from './no-restricted-call-result-use';
+import preferTypescriptOverJavascript from './prefer-typescript-over-javascript';
 import stringLiteralBlacklist from './string-literal-blacklist';
 import teamAnnotations from './team-annotations';
-import preferTypescriptOverJavascript from './prefer-typescript-over-javascript';
 
 // eslint-disable-next-line import/prefer-default-export
 export const rules = {
   'global-payroll-properties': globalPayrollProperties,
+  'no-dumb-quotes': noDumbQuotes,
   'no-restricted-call-result-use': noRestrictedCallResultUse,
+  'prefer-typescript-over-javascript': preferTypescriptOverJavascript,
   'string-literal-blacklist': stringLiteralBlacklist,
   'team-annotations': teamAnnotations,
-  'prefer-typescript-over-javascript': preferTypescriptOverJavascript,
 };

--- a/src/no-dumb-quotes.js
+++ b/src/no-dumb-quotes.js
@@ -10,5 +10,19 @@ export default function(context) {
         context.report(node, 'Use quotes (“…”) instead of inch marks ("…")');
       }
     },
+    TemplateLiteral(node) {
+      const { hasFootMark, hasInchMark } = node.quasis.reduce((booles, quasi) => ({
+        hasFootMark: booles.hasFootMark || /\D'/.test(quasi.value.cooked),
+        hasInchMark: booles.hasInchMark || /\D"/.test(quasi.value.cooked),
+      }), {});
+
+      if (hasFootMark) {
+        context.report(node, `Use an apostrophe (’) instead of a foot mark (')`);
+      }
+
+      if (hasInchMark) {
+        context.report(node, 'Use quotes (“…”) instead of inch marks ("…")');
+      }
+    },
   };
 }

--- a/src/no-dumb-quotes.js
+++ b/src/no-dumb-quotes.js
@@ -1,13 +1,16 @@
 export default function(context) {
+  const doubleQuoteError = 'Gusto uses smartquotes, replace with open quote “ option-[ and close quote ” option-shift-[ on a mac';
+  const singleQuoteError = 'Gusto uses smartquotes, replace with apostrophe ’ option-shift-] on a mac';
+
   return {
     Literal(node) {
       // \D = any non-digit so that using a foot or inch mark correctly i.e. 1' or 12" will not be captured
       if (/\D'/.test(node.value)) {
-        context.report(node, `Use an apostrophe (’) instead of a foot mark (')`);
+        context.report(node, singleQuoteError);
       }
 
       if (/\D"/.test(node.value)) {
-        context.report(node, 'Use quotes (“…”) instead of inch marks ("…")');
+        context.report(node, doubleQuoteError);
       }
     },
     TemplateLiteral(node) {
@@ -17,11 +20,11 @@ export default function(context) {
       }), {});
 
       if (hasFootMark) {
-        context.report(node, `Use an apostrophe (’) instead of a foot mark (')`);
+        context.report(node, singleQuoteError);
       }
 
       if (hasInchMark) {
-        context.report(node, 'Use quotes (“…”) instead of inch marks ("…")');
+        context.report(node, doubleQuoteError);
       }
     },
   };

--- a/src/no-dumb-quotes.js
+++ b/src/no-dumb-quotes.js
@@ -1,0 +1,14 @@
+export default function(context) {
+  return {
+    Literal(node) {
+      // \D = any non-digit so that using a foot or inch mark correctly i.e. 1' or 12" will not be captured
+      if (/\D'/.test(node.value)) {
+        context.report(node, `Use an apostrophe (’) instead of a foot mark (')`);
+      }
+
+      if (/\D"/.test(node.value)) {
+        context.report(node, 'Use quotes (“…”) instead of inch marks ("…")');
+      }
+    },
+  };
+}

--- a/tests/lib/rules/no-dumb-quotes.js
+++ b/tests/lib/rules/no-dumb-quotes.js
@@ -2,6 +2,8 @@ import rule from '../../../src/no-dumb-quotes';
 import { RuleTester } from 'eslint';
 
 const ruleTester = new RuleTester();
+const env = { es6: true }
+const stringForTemplate = ''
 
 ruleTester.run('no-dumb-quotes', rule, {
   valid: [
@@ -12,7 +14,12 @@ ruleTester.run('no-dumb-quotes', rule, {
       code: `var copy = 'A foot and 12" are equal'`,
     },
     {
-      code: `var copy = 'Maybe I don’t have anything “interesting” to say'`,
+      code: `const copy = 'Maybe I don’t have anything “interesting” to say'`,
+      env,
+    },
+    {
+      code: 'const value = "template literal"; const template = `This is a ${value} without dumb quotes`',
+      env,
     },
   ],
   invalid: [
@@ -23,6 +30,24 @@ ruleTester.run('no-dumb-quotes', rule, {
     {
       code: `var copy = 'have anything "interesting" to say'`,
       errors: [{ message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'Literal' }],
+    },
+    {
+      code: "const value = 'template literal'; const template = `This '${value}' has 'dumb' single quotes`",
+      env,
+      errors: [{ message: "Use an apostrophe (’) instead of a foot mark (')", type: 'TemplateLiteral' }],
+    },
+    {
+      code: 'const value = "template literal"; const template = `This "${value}" has "dumb" single quotes`',
+      env,
+      errors: [{ message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'TemplateLiteral' }],
+    },
+    {
+      code: 'const value = "template literal"; const template = `This \'${value}\' has both types of "dumb" quotes`',
+      env,
+      errors: [
+        { message: "Use an apostrophe (’) instead of a foot mark (')", type: 'TemplateLiteral' },
+        { message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'TemplateLiteral' },
+      ],
     },
   ]
 });

--- a/tests/lib/rules/no-dumb-quotes.js
+++ b/tests/lib/rules/no-dumb-quotes.js
@@ -3,7 +3,8 @@ import { RuleTester } from 'eslint';
 
 const ruleTester = new RuleTester();
 const env = { es6: true }
-const stringForTemplate = ''
+const doubleQuoteError = 'Gusto uses smartquotes, replace with open quote “ option-[ and close quote ” option-shift-[ on a mac';
+const singleQuoteError = 'Gusto uses smartquotes, replace with apostrophe ’ option-shift-] on a mac';
 
 ruleTester.run('no-dumb-quotes', rule, {
   valid: [
@@ -25,28 +26,28 @@ ruleTester.run('no-dumb-quotes', rule, {
   invalid: [
     {
       code: `var copy = "Maybe I don't"`,
-      errors: [{ message: "Use an apostrophe (’) instead of a foot mark (')", type: 'Literal' }],
+      errors: [{ message: singleQuoteError, type: 'Literal' }],
     },
     {
       code: `var copy = 'have anything "interesting" to say'`,
-      errors: [{ message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'Literal' }],
+      errors: [{ message: doubleQuoteError, type: 'Literal' }],
     },
     {
       code: "const value = 'template literal'; const template = `This '${value}' has 'dumb' single quotes`",
       env,
-      errors: [{ message: "Use an apostrophe (’) instead of a foot mark (')", type: 'TemplateLiteral' }],
+      errors: [{ message: singleQuoteError, type: 'TemplateLiteral' }],
     },
     {
-      code: 'const value = "template literal"; const template = `This "${value}" has "dumb" single quotes`',
+      code: 'const value = "template literal"; const template = `This "${value}" has "dumb" double quotes`',
       env,
-      errors: [{ message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'TemplateLiteral' }],
+      errors: [{ message: doubleQuoteError, type: 'TemplateLiteral' }],
     },
     {
       code: 'const value = "template literal"; const template = `This \'${value}\' has both types of "dumb" quotes`',
       env,
       errors: [
-        { message: "Use an apostrophe (’) instead of a foot mark (')", type: 'TemplateLiteral' },
-        { message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'TemplateLiteral' },
+        { message: singleQuoteError, type: 'TemplateLiteral' },
+        { message: doubleQuoteError, type: 'TemplateLiteral' },
       ],
     },
   ]

--- a/tests/lib/rules/no-dumb-quotes.js
+++ b/tests/lib/rules/no-dumb-quotes.js
@@ -1,0 +1,28 @@
+import rule from '../../../src/no-dumb-quotes';
+import { RuleTester } from 'eslint';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-dumb-quotes', rule, {
+  valid: [
+    {
+      code: `var copy = "12 inches and 1' are equal"`,
+    },
+    {
+      code: `var copy = 'A foot and 12" are equal'`,
+    },
+    {
+      code: `var copy = 'Maybe I don’t have anything “interesting” to say'`,
+    },
+  ],
+  invalid: [
+    {
+      code: `var copy = "Maybe I don't"`,
+      errors: [{ message: "Use an apostrophe (’) instead of a foot mark (')", type: 'Literal' }],
+    },
+    {
+      code: `var copy = 'have anything "interesting" to say'`,
+      errors: [{ message: 'Use quotes (“…”) instead of inch marks ("…")', type: 'Literal' }],
+    },
+  ]
+});


### PR DESCRIPTION
We have a rule in the `.eslintrc.js` file called `'react/no-unescaped-entities'` to prevent use of dumb quotes. 
![existing_rule](https://user-images.githubusercontent.com/562107/178345679-aca70540-2fc3-4f26-85f6-16529671f589.png)

but this rule only finds the dumb quotes that are directly inside the React elements and misses those that are in code.

![not_caught](https://user-images.githubusercontent.com/562107/178346433-20a2b12d-8568-4c1f-a228-c3d4142d4670.png)

As a result we have potentially 1,000s of violations. 

![many_violations](https://user-images.githubusercontent.com/562107/178346845-52c873b5-eb27-4613-9625-3f10cff311ab.png)

A lot if not most are in comments like `// Empirically, we've...` but many are seen by the user `"Owner": "Owner's draw"`

I searched online to find a eslint rule to catch these but haven't found a good plugin, let me know if one already exists. Until then I have a simple eslint plugin that will catch many of our errors

![eslint-plugin](https://user-images.githubusercontent.com/562107/178347544-9691ff8b-d6e8-4192-a471-8e5f2d40fecc.png)
